### PR TITLE
Fix typo causing dependency error for case sensitive file systems

### DIFF
--- a/exercises/applicative/applicative_exercises.js
+++ b/exercises/applicative/applicative_exercises.js
@@ -1,6 +1,6 @@
 require('lambdajs').expose(global);
 require('pointfree-fantasy').expose(global);
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var IO = require('../../lib/io');
 var Future = require('data.future');
 var _ = require('ramda');

--- a/exercises/applicative/applicative_exercises_spec.js
+++ b/exercises/applicative/applicative_exercises_spec.js
@@ -1,6 +1,6 @@
 var E = require('./applicative_exercises');
 var assert = require("chai").assert
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Either = require('data.either');
 var _ = require('ramda');

--- a/exercises/functors/functor_exercises.js
+++ b/exercises/functors/functor_exercises.js
@@ -1,6 +1,6 @@
 require('lambdajs').expose(global);
 require('pointfree-fantasy').expose(this);
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Future = require('data.future');
 var Either = require('data.either');

--- a/exercises/functors/functor_exercises_spec.js
+++ b/exercises/functors/functor_exercises_spec.js
@@ -1,6 +1,6 @@
 var E = require('./functor_exercises');
 var assert = require("chai").assert
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Either = require('data.either');
 var Left = Either.Left;

--- a/exercises/monads/monad_exercises.js
+++ b/exercises/monads/monad_exercises.js
@@ -1,6 +1,6 @@
 require('lambdajs').expose(global);
 require('pointfree-fantasy').expose(global);
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var IO = require('../../lib/io');
 var Future = require('data.future');
 var _ = require('ramda');

--- a/exercises/monads/monad_exercises_spec.js
+++ b/exercises/monads/monad_exercises_spec.js
@@ -1,6 +1,6 @@
 var E = require('./monad_exercises');
 var assert = require("chai").assert
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Either = require('data.either');
 var _ = require('ramda');

--- a/exercises/monoids/monoid_exercises_spec.js
+++ b/exercises/monoids/monoid_exercises_spec.js
@@ -1,6 +1,6 @@
 var E = require('./monoid_exercises');
 var assert = require("chai").assert
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Either = require('data.either');
 var _ = require('ramda');

--- a/exercises_answers/applicative/applicative_answers.js
+++ b/exercises_answers/applicative/applicative_answers.js
@@ -1,6 +1,6 @@
 require('lambdajs').expose(global);
 require('pointfree-fantasy').expose(global);
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var IO = require('../../lib/io');
 var Future = require('data.future');
 var _ = require('ramda');

--- a/exercises_answers/applicative/applicative_answers_spec.js
+++ b/exercises_answers/applicative/applicative_answers_spec.js
@@ -1,6 +1,6 @@
 var E = require('./applicative_answers');
 var assert = require("chai").assert
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Either = require('data.either');
 var _ = require('ramda');

--- a/exercises_answers/functors/functor_answers.js
+++ b/exercises_answers/functors/functor_answers.js
@@ -1,6 +1,6 @@
 require('lambdajs').expose(global);
 require('pointfree-fantasy').expose(this);
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Future = require('data.future');
 var Either = require('data.either');

--- a/exercises_answers/functors/functor_exercises_spec.js
+++ b/exercises_answers/functors/functor_exercises_spec.js
@@ -1,6 +1,6 @@
 var E = require('./functor_answers');
 var assert = require("chai").assert
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Either = require('data.either');
 var Left = Either.Left;

--- a/exercises_answers/monads/monad_answers.js
+++ b/exercises_answers/monads/monad_answers.js
@@ -1,6 +1,6 @@
 require('lambdajs').expose(global);
 require('pointfree-fantasy').expose(global);
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var IO = require('../../lib/io');
 var Future = require('data.future');
 var _ = require('ramda');

--- a/exercises_answers/monads/monad_exercises_spec.js
+++ b/exercises_answers/monads/monad_exercises_spec.js
@@ -1,6 +1,6 @@
 var E = require('./monad_answers');
 var assert = require("chai").assert
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Either = require('data.either');
 var _ = require('ramda');

--- a/exercises_answers/monoids/monoid_answers_spec.js
+++ b/exercises_answers/monoids/monoid_answers_spec.js
@@ -1,6 +1,6 @@
 var E = require('./monoid_answers');
 var assert = require("chai").assert
-var Maybe = require('pointfree-fantasy/instances/Maybe');
+var Maybe = require('pointfree-fantasy/instances/maybe');
 var Identity = require('fantasy-identities');
 var Either = require('data.either');
 var _ = require('ramda');


### PR DESCRIPTION
The file path for `var Maybe = require( ... );` used incorrect capitalization. This is apparently a problem for Linux machines, but not Macs. This issue was discovered when Ubuntu machine couldn't run Mocha tests.